### PR TITLE
WIP: master Mars rebase

### DIFF
--- a/src/EnvireJointManager.hpp
+++ b/src/EnvireJointManager.hpp
@@ -90,6 +90,7 @@ namespace mars {
                                  bool first_axis = 1);
 
       virtual unsigned long getID(const std::string &joint_name) const;
+      virtual unsigned long getIDByNodeIDs(unsigned long id1, unsigned long id2);
       virtual bool getDataBrokerNames(unsigned long id, std::string *groupName,
                                       std::string *dataName) const;
       virtual void setOfflineValue(unsigned long id, mars::interfaces::sReal value);

--- a/src/EnvireManager.cpp
+++ b/src/EnvireManager.cpp
@@ -36,7 +36,7 @@
 #include <mars/interfaces/sim/LoadCenter.h>
 
 #include <configmaps/ConfigData.h>
-#include <base/Logging.hpp>
+#include <base-logging/Logging.hpp>
 
 #include "EnvireStorageManager.hpp"
 #include "EnvireMotorManager.hpp"

--- a/src/EnvireNodeManager.hpp
+++ b/src/EnvireNodeManager.hpp
@@ -85,6 +85,7 @@ namespace mars {
             virtual mars::interfaces::NodeId addTerrain(mars::interfaces::terrainStruct *terrainS);
             virtual std::vector<mars::interfaces::NodeId> addNode(std::vector<mars::interfaces::NodeData> v_NodeData);
             virtual mars::interfaces::NodeId addPrimitive(mars::interfaces::NodeData *snode);
+            virtual bool exists(mars::interfaces::NodeId id) const;
             virtual int getNodeCount() const;
             virtual mars::interfaces::NodeId getNextNodeID() const;
             virtual void editNode(mars::interfaces::NodeData *nodeS, int changes);
@@ -153,6 +154,7 @@ namespace mars {
              * \return Id of the node if it exists, otherwise 0
              */
             virtual mars::interfaces::NodeId getID(const std::string& node_name) const;
+            virtual std::vector<interfaces::NodeId> getNodeIDs(const std::string& str_in_name) const;
             virtual double getCollisionDepth(mars::interfaces::NodeId id) const;
             virtual bool getDataBrokerNames(mars::interfaces::NodeId id, std::string *groupName,
                                             std::string *dataName) const;


### PR DESCRIPTION
Adds some methods to the EnvireManager and the JointManager which have been newly included in the Node and Joint Manager interfaces of Mars Core.

Until the [envire fork of mars core](https://github.com/annaborn/mars/tree/envire), that this package is compatible with, has not been updated/rebased, this merge request should not be accepted.

Here is [the builconf branch on which we have set the overrides](https://github.com/Rauldg/simulation-buildconf/tree/master_mars_rebase) that we are using to work on this issue.